### PR TITLE
Remove default gh-action  parameter

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -13,7 +13,7 @@ inputs:
   flags:
     description: 'Specify updatecli command flags'
     required: false
-    default: '--config ./updatecli/updatecli.d --values updatecli/values.yaml'
+    default: ''
 runs:
   using: 'docker'
   image: Dockerfile


### PR DESCRIPTION
Only rely on updatecli default parameter