### PR TITLE
feat: allow customization in the image when using a shell resource. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,22 @@ ARG UPDATECLI_VERSION=v0.7.1
 
 FROM ghcr.io/updatecli/updatecli:$UPDATECLI_VERSION
 
-COPY github-actions-entrypoint.bash /usr/local/bin/github-actions-entrypoint.bash 
+## As per https://docs.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions#user
+# hadolint ignore=DL3002
+USER root
+WORKDIR /root
+
+## The latest version of these "generic" package is always required
+# hadolint ignore=DL3008
+RUN apt-get update && \
+  apt-get install --yes --no-install-recommends \
+    curl \
+    tar \
+    unzip \
+    wget \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY github-actions-entrypoint.bash /usr/local/bin/github-actions-entrypoint.bash
 
 ENTRYPOINT ["/usr/local/bin/github-actions-entrypoint.bash"]


### PR DESCRIPTION
Closes #21

This PR introduces the following changes:

- Define the default user as "root" to fulfill GitHub's recommendations in https://docs.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions#user
  - Working Dir is set back to `/root` for coherency, but this is not necessary as GitHub overrides the "WORKDIR" option at runtime as per https://docs.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions#workdir

- Install a few "common" packages (curl, wget, tar and zip) to allow a minimum use cases.
  - The size penalty is 5Mb (128Mb to 133 Mb on my local Docker Engine, with uncompressed layers)
  - This might be reconsidered because GitHub rebuils the images at execution time so hoping this addon does not slow executions