### PR TITLE
Fix releaseworkflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,7 +5,7 @@ on:
   push:
     # branches to consider in the event; optional, defaults to all
     branches:
-      - main
+      - v2
 
 jobs:
   update_release_draft:

--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -5,7 +5,8 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
+      - v1
+      - v2
   schedule:
     # Run once a day
     - cron: '*/10 * * * *'


### PR DESCRIPTION
The GitHub action release process is broken since I introduce a "v2".
I created the branch "v1" to keep the previous action based on Docker and a second branch "v2" for the javascript one.
In order to use the either `uses: updatecli/updatecli-action@v1` or `uses: updatecli/updatecli-action@v2` we needs to maintain those two branches.
I am not interested to create new releases on branch v1,so I am not planning to make release-drafter work on both branches. Therefor I am switching the release-drafter from running on main to v2

## Description

I propose to  now run release-drafter from the v2 branch and have updatecli workflow different depending on the v1 and v2 branch

## Test

To test this pull request, you can run the following commands:

```shell
cp <to_package_directory>
go test
```

## Additional Information

### Tradeoff
I considered dropping the branch v2 in favor of main, but then I lose the ability to use "`uses: updatecli/updatecli-action@v2`"

### Potential improvement

* Switch the default repository branch to v2
* Remove the branch `main`
