### PR TITLE
chore(gh-workflows) use action/checkout v3 to remove nodeJS 12 warnings

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: "Setup updatecli"
         uses: "updatecli/updatecli-action@v2.15.0"


### PR DESCRIPTION
Ref. https://github.com/updatecli/updatecli-action/actions/runs/3542732273

<img width="2020" alt="Capture d’écran 2022-11-24 à 18 45 13" src="https://user-images.githubusercontent.com/1522731/203842620-e70fca5f-4366-465b-84fa-60d06a739dc3.png">
