### PR TITLE
updatecli github action can use the branch

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: "Setup updatecli"
-        uses: "updatecli/updatecli-action@v2.27.0"
+        uses: "updatecli/updatecli-action@v2"
 
       - name: "Run updatecli in dryrun"
         run: "updatecli diff --config ./updatecli/updatecli.d"


### PR DESCRIPTION
On this repository, I usually prefer to use the latest Updatecli version available for the github action

## Description

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cp <to_package_directory>
go test
```

## Additional Information

### Tradeoff

Broken behavior appears faster

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
